### PR TITLE
Create Next.js artist portfolio template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# artist-portfolio
+# Artist Portfolio Template
+
+A simple and reusable artist portfolio website template built with **Next.js** and **Tailwind CSS**. This project uses **DecapCMS** (Netlify CMS) for content management and can be deployed for free on **Vercel** or **Netlify**.
+
+## Features
+
+- Static site built with Next.js
+- Tailwind CSS for styling
+- DecapCMS for editing content (artworks, about page, SEO)
+- Contact form using Netlify Forms or Formspree free tier
+- SEO-friendly with customizable meta tags
+- Ready to duplicate via GitHub template for multiple artists
+
+## Getting Started
+
+```bash
+# Install dependencies
+npm install
+
+# Run the development server
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the site in your browser.
+
+## Deployment
+
+### Deploy to Vercel
+
+1. Push this repository to GitHub.
+2. In Vercel, create a new project and import the repository.
+3. Set any environment variables if needed (none by default).
+4. Deploy!
+
+### Deploy to Netlify
+
+1. Push this repository to GitHub.
+2. In Netlify, create a new site from Git.
+3. Choose this repository and deploy with the default settings.
+4. Netlify Forms will automatically capture submissions from the contact form.
+
+## Configuring for Each Artist
+
+- **Logo:** place a logo file in `public/images/logo.png`.
+- **Colors & Fonts:** edit `tailwind.config.js` or add custom CSS in `src/styles/globals.css`.
+- **Content:** log in to `/admin` (DecapCMS) and edit artworks, about page, and SEO settings.
+
+## Duplicating the Template
+
+1. Click **Use this template** on GitHub to create a new repository for an artist.
+2. Update content via CMS or by editing the files in `content/`.
+3. Deploy the new repository to Vercel or Netlify.
+
+## Future Ecommerce
+
+The project structure leaves room to integrate an e‑commerce solution such as Snipcart or the Shopify Buy SDK in the future. No e‑commerce functionality is currently implemented.
+
+## License
+
+MIT

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,5 @@
+---
+title: About the Artist
+---
+
+This is a sample biography. Replace it with the artist's story.

--- a/content/artworks/sample-artwork.md
+++ b/content/artworks/sample-artwork.md
@@ -1,0 +1,7 @@
+---
+title: Sample Artwork
+slug: sample-artwork
+image: /images/uploads/sample.jpg
+---
+
+This is a sample description of an artwork.

--- a/content/seo.md
+++ b/content/seo.md
@@ -1,0 +1,4 @@
+---
+meta_title: Artist Portfolio
+meta_description: Portfolio website showcasing artworks.
+---

--- a/decapcms/config.yml
+++ b/decapcms/config.yml
@@ -1,0 +1,35 @@
+backend:
+  name: git-gateway
+  branch: main
+
+media_folder: "public/images/uploads"
+public_folder: "/images/uploads"
+
+collections:
+  - name: "artworks"
+    label: "Artworks"
+    folder: "content/artworks"
+    create: true
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Slug", name: "slug", widget: "string" }
+      - { label: "Image", name: "image", widget: "image" }
+      - { label: "Body", name: "body", widget: "markdown" }
+  - name: "about"
+    label: "About"
+    files:
+      - file: "content/about.md"
+        label: "About"
+        name: "about"
+        fields:
+          - { label: "Title", name: "title", widget: "string" }
+          - { label: "Body", name: "body", widget: "markdown" }
+  - name: "seo"
+    label: "SEO"
+    files:
+      - file: "content/seo.md"
+        label: "SEO"
+        name: "seo"
+        fields:
+          - { label: "Meta Title", name: "meta_title", widget: "string" }
+          - { label: "Meta Description", name: "meta_description", widget: "text" }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+  publish = "out"
+
+[[redirects]]
+  from = "/admin"
+  to = "/admin/index.html"
+  status = 200

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "artist-portfolio-template",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "gray-matter": "5.1.1",
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "remark": "15.0.0",
+    "remark-html": "15.0.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,1 @@
+../../decapcms/config.yml

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Content Manager</title>
+    <script src="https://unpkg.com/netlify-cms@^2/dist/netlify-cms.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/components/ArtworkCard.jsx
+++ b/src/components/ArtworkCard.jsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function ArtworkCard({ artwork }) {
+  return (
+    <div className="p-4">
+      <Link href={`/artwork/${artwork.slug}`} className="block">
+        <img src={artwork.image} alt={artwork.title} className="w-full h-auto" />
+        <h3 className="mt-2 text-xl font-semibold">{artwork.title}</h3>
+      </Link>
+    </div>
+  )
+}

--- a/src/components/ArtworkGrid.jsx
+++ b/src/components/ArtworkGrid.jsx
@@ -1,0 +1,11 @@
+import ArtworkCard from './ArtworkCard'
+
+export default function ArtworkGrid({ artworks }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      {artworks.map((art) => (
+        <ArtworkCard key={art.slug} artwork={art} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/SEOHead.jsx
+++ b/src/components/SEOHead.jsx
@@ -1,0 +1,11 @@
+import Head from 'next/head'
+
+export default function SEOHead({ title, description }) {
+  return (
+    <Head>
+      <title>{title ? `${title} | Artist Portfolio` : 'Artist Portfolio'}</title>
+      {description && <meta name="description" content={description} />}
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </Head>
+  )
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,49 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { remark } from 'remark'
+import html from 'remark-html'
+
+const artworksDirectory = path.join(process.cwd(), 'content/artworks')
+
+export function getAllArtworks() {
+  const fileNames = fs.readdirSync(artworksDirectory)
+  const artworks = fileNames.map((fileName) => {
+    const fullPath = path.join(artworksDirectory, fileName)
+    const fileContents = fs.readFileSync(fullPath, 'utf8')
+    const { data, content } = matter(fileContents)
+    return {
+      ...data,
+      description: content.trim()
+    }
+  })
+  return artworks
+}
+
+export async function getArtworkBySlug(slug) {
+  const fullPath = path.join(artworksDirectory, `${slug}.md`)
+  const fileContents = fs.readFileSync(fullPath, 'utf8')
+  const { data, content } = matter(fileContents)
+  const processed = await remark().use(html).process(content)
+  const htmlContent = processed.toString()
+  return {
+    ...data,
+    html: htmlContent
+  }
+}
+
+export function getAllArtworkSlugs() {
+  return fs.readdirSync(artworksDirectory).map((fileName) => fileName.replace(/\.md$/, ''))
+}
+
+export function getAbout() {
+  const file = fs.readFileSync(path.join(process.cwd(), 'content/about.md'), 'utf8')
+  const { data, content } = matter(file)
+  return { ...data, content }
+}
+
+export function getSEO() {
+  const file = fs.readFileSync(path.join(process.cwd(), 'content/seo.md'), 'utf8')
+  const { data } = matter(file)
+  return data
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,0 +1,23 @@
+import SEOHead from '../components/SEOHead'
+import { getAbout } from '../lib/api'
+import { remark } from 'remark'
+import html from 'remark-html'
+
+export default function About({ about }) {
+  return (
+    <>
+      <SEOHead title={about.title} />
+      <main className="container mx-auto p-4">
+        <h1 className="text-4xl font-bold mb-4">{about.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: about.html }} />
+      </main>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  const data = getAbout()
+  const processed = await remark().use(html).process(data.content)
+  data.html = processed.toString()
+  return { props: { about: data } }
+}

--- a/src/pages/artwork/[slug].js
+++ b/src/pages/artwork/[slug].js
@@ -1,0 +1,28 @@
+import SEOHead from '../../components/SEOHead'
+import { getAllArtworkSlugs, getArtworkBySlug } from '../../lib/api'
+
+export default function ArtworkDetail({ artwork }) {
+  return (
+    <>
+      <SEOHead title={artwork.title} />
+      <main className="container mx-auto p-4">
+        <h1 className="text-4xl font-bold mb-4">{artwork.title}</h1>
+        <img src={artwork.image} alt={artwork.title} className="w-full h-auto" />
+        <div className="mt-4" dangerouslySetInnerHTML={{ __html: artwork.html }} />
+      </main>
+    </>
+  )
+}
+
+export async function getStaticPaths() {
+  const slugs = getAllArtworkSlugs()
+  return {
+    paths: slugs.map((slug) => ({ params: { slug } })),
+    fallback: false
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const artwork = await getArtworkBySlug(params.slug)
+  return { props: { artwork } }
+}

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,0 +1,28 @@
+import SEOHead from '../components/SEOHead'
+
+export default function Contact() {
+  return (
+    <>
+      <SEOHead title="Contact" />
+      <main className="container mx-auto p-4">
+        <h1 className="text-4xl font-bold mb-4">Contact</h1>
+        <form name="contact" method="POST" data-netlify="true" className="max-w-md">
+          <input type="hidden" name="form-name" value="contact" />
+          <div className="mb-4">
+            <label className="block">Name</label>
+            <input type="text" name="name" required className="w-full border p-2" />
+          </div>
+          <div className="mb-4">
+            <label className="block">Email</label>
+            <input type="email" name="email" required className="w-full border p-2" />
+          </div>
+          <div className="mb-4">
+            <label className="block">Message</label>
+            <textarea name="message" required className="w-full border p-2" />
+          </div>
+          <button type="submit" className="px-4 py-2 bg-black text-white">Send</button>
+        </form>
+      </main>
+    </>
+  )
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,23 @@
+import ArtworkGrid from '../components/ArtworkGrid'
+import SEOHead from '../components/SEOHead'
+import { getAllArtworks, getSEO } from '../lib/api'
+
+export default function Home({ artworks, seo }) {
+  return (
+    <>
+      <SEOHead title={seo.meta_title} description={seo.meta_description} />
+      <main className="container mx-auto p-4">
+        <h1 className="text-4xl font-bold mb-4">Featured Artworks</h1>
+        <ArtworkGrid artworks={artworks} />
+      </main>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  const artworks = getAllArtworks()
+  const seo = getSEO()
+  return {
+    props: { artworks, seo }
+  }
+}

--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -1,0 +1,20 @@
+import ArtworkGrid from '../components/ArtworkGrid'
+import SEOHead from '../components/SEOHead'
+import { getAllArtworks } from '../lib/api'
+
+export default function Portfolio({ artworks }) {
+  return (
+    <>
+      <SEOHead title="Portfolio" />
+      <main className="container mx-auto p-4">
+        <h1 className="text-4xl font-bold mb-4">Portfolio</h1>
+        <ArtworkGrid artworks={artworks} />
+      </main>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  const artworks = getAllArtworks()
+  return { props: { artworks } }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: sans-serif;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,jsx}',
+    './src/components/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- set up Next.js + Tailwind project
- add DecapCMS configuration and sample content
- implement portfolio components and pages
- configure Netlify build and forms
- document usage in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684920eaa848833186642eff8cfccfb4