### PR TITLE
Enhance portfolio with layout and polished pages

### DIFF
--- a/src/components/ArtworkCard.jsx
+++ b/src/components/ArtworkCard.jsx
@@ -2,10 +2,24 @@ import Link from 'next/link'
 
 export default function ArtworkCard({ artwork }) {
   return (
-    <div className="p-4">
-      <Link href={`/artwork/${artwork.slug}`} className="block">
-        <img src={artwork.image} alt={artwork.title} className="w-full h-auto" />
-        <h3 className="mt-2 text-xl font-semibold">{artwork.title}</h3>
+    <div className="group">
+      <Link
+        href={`/artwork/${artwork.slug}`}
+        className="block overflow-hidden rounded-lg shadow hover:shadow-lg transition"
+      >
+        <img
+          src={artwork.image}
+          alt={artwork.title}
+          className="w-full h-56 object-cover"
+        />
+        <div className="p-4">
+          <h3 className="text-lg font-semibold group-hover:underline">
+            {artwork.title}
+          </h3>
+          {artwork.description && (
+            <p className="text-sm text-gray-600 mt-1">{artwork.description}</p>
+          )}
+        </div>
       </Link>
     </div>
   )

--- a/src/components/ArtworkGrid.jsx
+++ b/src/components/ArtworkGrid.jsx
@@ -2,7 +2,7 @@ import ArtworkCard from './ArtworkCard'
 
 export default function ArtworkGrid({ artworks }) {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
       {artworks.map((art) => (
         <ArtworkCard key={art.slug} artwork={art} />
       ))}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+
+export default function Layout({ children }) {
+  return (
+    <div className="flex flex-col min-h-screen font-sans text-gray-900">
+      <nav className="py-6 px-4 md:px-8 border-b">
+        <div className="max-w-5xl mx-auto flex items-center justify-between">
+          <Link href="/" className="text-2xl font-bold">Artist Portfolio</Link>
+          <div className="space-x-4">
+            <Link href="/" className="hover:underline">Home</Link>
+            <Link href="/portfolio" className="hover:underline">Portfolio</Link>
+            <Link href="/about" className="hover:underline">About</Link>
+            <Link href="/contact" className="hover:underline">Contact</Link>
+          </div>
+        </div>
+      </nav>
+      <main className="flex-grow max-w-5xl mx-auto w-full px-4 md:px-8 py-8">
+        {children}
+      </main>
+      <footer className="border-t py-6 px-4 md:px-8">
+        <div className="max-w-5xl mx-auto text-center text-sm text-gray-500">
+          &copy; {new Date().getFullYear()} Artist Portfolio. All rights reserved.
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/components/SEOHead.jsx
+++ b/src/components/SEOHead.jsx
@@ -6,6 +6,7 @@ export default function SEOHead({ title, description }) {
       <title>{title ? `${title} | Artist Portfolio` : 'Artist Portfolio'}</title>
       {description && <meta name="description" content={description} />}
       <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta charSet="utf-8" />
     </Head>
   )
 }

--- a/src/lib/dummyData.js
+++ b/src/lib/dummyData.js
@@ -1,0 +1,49 @@
+export const dummyArtworks = [
+  {
+    title: 'Sunset Dreams',
+    slug: 'sunset-dreams',
+    image: 'https://source.unsplash.com/800x600/?sunset,art',
+    html: '<p>A vivid exploration of color and light inspired by evening skies.</p>',
+    description: 'A vivid exploration of color and light inspired by evening skies.'
+  },
+  {
+    title: 'Urban Lines',
+    slug: 'urban-lines',
+    image: 'https://source.unsplash.com/800x600/?city,art',
+    html: '<p>Geometry and rhythm intersect in this study of urban architecture.</p>',
+    description: 'Geometry and rhythm intersect in this study of urban architecture.'
+  },
+  {
+    title: 'Nature Whisper',
+    slug: 'nature-whisper',
+    image: 'https://source.unsplash.com/800x600/?nature,art',
+    html: '<p>An homage to the quiet moments found in wild landscapes.</p>',
+    description: 'An homage to the quiet moments found in wild landscapes.'
+  },
+  {
+    title: 'Abstract Flow',
+    slug: 'abstract-flow',
+    image: 'https://source.unsplash.com/800x600/?abstract,art',
+    html: '<p>Organic shapes and vibrant colors merge in continuous motion.</p>',
+    description: 'Organic shapes and vibrant colors merge in continuous motion.'
+  },
+  {
+    title: 'Monochrome Mood',
+    slug: 'monochrome-mood',
+    image: 'https://source.unsplash.com/800x600/?blackandwhite,art',
+    html: '<p>A study in light and shadow capturing raw emotion.</p>',
+    description: 'A study in light and shadow capturing raw emotion.'
+  },
+  {
+    title: 'Ocean Echoes',
+    slug: 'ocean-echoes',
+    image: 'https://source.unsplash.com/800x600/?ocean,art',
+    html: '<p>Textures and tones inspired by the endless sea.</p>',
+    description: 'Textures and tones inspired by the endless sea.'
+  }
+]
+
+export const dummyAbout = {
+  title: 'About the Artist',
+  html: '<p>This is sample text about the artist. It describes a creative journey and artistic vision.</p>'
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,10 @@
 import '../styles/globals.css'
+import Layout from '../components/Layout'
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,5 +1,6 @@
 import SEOHead from '../components/SEOHead'
 import { getAbout } from '../lib/api'
+import { dummyAbout } from '../lib/dummyData'
 import { remark } from 'remark'
 import html from 'remark-html'
 
@@ -7,17 +8,24 @@ export default function About({ about }) {
   return (
     <>
       <SEOHead title={about.title} />
-      <main className="container mx-auto p-4">
-        <h1 className="text-4xl font-bold mb-4">{about.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: about.html }} />
-      </main>
+      <div>
+        <h1 className="text-4xl font-bold mb-8 text-center">{about.title}</h1>
+        <div
+          className="prose mx-auto"
+          dangerouslySetInnerHTML={{ __html: about.html }}
+        />
+      </div>
     </>
   )
 }
 
 export async function getStaticProps() {
-  const data = getAbout()
-  const processed = await remark().use(html).process(data.content)
-  data.html = processed.toString()
-  return { props: { about: data } }
+  try {
+    const data = getAbout()
+    const processed = await remark().use(html).process(data.content)
+    data.html = processed.toString()
+    return { props: { about: data } }
+  } catch (e) {
+    return { props: { about: dummyAbout } }
+  }
 }

--- a/src/pages/artwork/[slug].js
+++ b/src/pages/artwork/[slug].js
@@ -5,11 +5,18 @@ export default function ArtworkDetail({ artwork }) {
   return (
     <>
       <SEOHead title={artwork.title} />
-      <main className="container mx-auto p-4">
-        <h1 className="text-4xl font-bold mb-4">{artwork.title}</h1>
-        <img src={artwork.image} alt={artwork.title} className="w-full h-auto" />
-        <div className="mt-4" dangerouslySetInnerHTML={{ __html: artwork.html }} />
-      </main>
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-4xl font-bold mb-8 text-center">{artwork.title}</h1>
+        <img
+          src={artwork.image}
+          alt={artwork.title}
+          className="w-full h-auto mb-8 rounded"
+        />
+        <div
+          className="prose mx-auto"
+          dangerouslySetInnerHTML={{ __html: artwork.html }}
+        />
+      </div>
     </>
   )
 }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -4,25 +4,50 @@ export default function Contact() {
   return (
     <>
       <SEOHead title="Contact" />
-      <main className="container mx-auto p-4">
-        <h1 className="text-4xl font-bold mb-4">Contact</h1>
-        <form name="contact" method="POST" data-netlify="true" className="max-w-md">
+      <div className="max-w-xl mx-auto">
+        <h1 className="text-4xl font-bold mb-8 text-center">Contact</h1>
+        <form
+          name="contact"
+          method="POST"
+          data-netlify="true"
+          className="space-y-6"
+        >
           <input type="hidden" name="form-name" value="contact" />
-          <div className="mb-4">
-            <label className="block">Name</label>
-            <input type="text" name="name" required className="w-full border p-2" />
+          <div>
+            <label className="block mb-1 font-medium">Name</label>
+            <input
+              type="text"
+              name="name"
+              required
+              className="w-full border border-gray-300 rounded p-3"
+            />
           </div>
-          <div className="mb-4">
-            <label className="block">Email</label>
-            <input type="email" name="email" required className="w-full border p-2" />
+          <div>
+            <label className="block mb-1 font-medium">Email</label>
+            <input
+              type="email"
+              name="email"
+              required
+              className="w-full border border-gray-300 rounded p-3"
+            />
           </div>
-          <div className="mb-4">
-            <label className="block">Message</label>
-            <textarea name="message" required className="w-full border p-2" />
+          <div>
+            <label className="block mb-1 font-medium">Message</label>
+            <textarea
+              name="message"
+              required
+              rows="5"
+              className="w-full border border-gray-300 rounded p-3"
+            />
           </div>
-          <button type="submit" className="px-4 py-2 bg-black text-white">Send</button>
+          <button
+            type="submit"
+            className="px-6 py-3 bg-black text-white rounded hover:bg-gray-800"
+          >
+            Send Message
+          </button>
         </form>
-      </main>
+      </div>
     </>
   )
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,15 +1,38 @@
 import ArtworkGrid from '../components/ArtworkGrid'
 import SEOHead from '../components/SEOHead'
-import { getAllArtworks, getSEO } from '../lib/api'
+import { getAllArtworks, getSEO, getAbout } from '../lib/api'
+import { dummyArtworks, dummyAbout } from '../lib/dummyData'
 
-export default function Home({ artworks, seo }) {
+export default function Home({ artworks, seo, about }) {
   return (
     <>
       <SEOHead title={seo.meta_title} description={seo.meta_description} />
-      <main className="container mx-auto p-4">
-        <h1 className="text-4xl font-bold mb-4">Featured Artworks</h1>
-        <ArtworkGrid artworks={artworks} />
-      </main>
+      <section className="text-center py-16">
+        <h1 className="text-5xl font-bold mb-4">Welcome to My Art World</h1>
+        <p className="text-lg text-gray-600 mb-8 max-w-2xl mx-auto">
+          Discover a curated selection of artworks and creative projects.
+        </p>
+        <a
+          href="/portfolio"
+          className="inline-block px-6 py-3 bg-black text-white rounded hover:bg-gray-800"
+        >
+          View Portfolio
+        </a>
+      </section>
+      <section className="py-16 bg-gray-50">
+        <h2 className="text-3xl font-bold mb-8 text-center">Featured Artworks</h2>
+        <ArtworkGrid artworks={artworks.slice(0, 3)} />
+      </section>
+      <section className="py-16 text-center">
+        <h2 className="text-3xl font-bold mb-4">About</h2>
+        <div
+          className="prose mx-auto"
+          dangerouslySetInnerHTML={{ __html: about.html }}
+        />
+        <a href="/contact" className="mt-8 inline-block underline text-lg">
+          Get in touch
+        </a>
+      </section>
     </>
   )
 }
@@ -17,7 +40,18 @@ export default function Home({ artworks, seo }) {
 export async function getStaticProps() {
   const artworks = getAllArtworks()
   const seo = getSEO()
+  const about = await (async () => {
+    try {
+      const data = getAbout()
+      const { remark } = await import('remark')
+      const html = (await remark().use((await import('remark-html')).default).process(data.content)).toString()
+      return { ...data, html }
+    } catch (e) {
+      return dummyAbout
+    }
+  })()
+  const usableArtworks = artworks && artworks.length > 0 ? artworks : dummyArtworks
   return {
-    props: { artworks, seo }
+    props: { artworks: usableArtworks, seo, about }
   }
 }

--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -1,20 +1,25 @@
 import ArtworkGrid from '../components/ArtworkGrid'
 import SEOHead from '../components/SEOHead'
 import { getAllArtworks } from '../lib/api'
+import { dummyArtworks } from '../lib/dummyData'
 
 export default function Portfolio({ artworks }) {
   return (
     <>
       <SEOHead title="Portfolio" />
-      <main className="container mx-auto p-4">
-        <h1 className="text-4xl font-bold mb-4">Portfolio</h1>
+      <div>
+        <h1 className="text-4xl font-bold mb-8 text-center">Portfolio</h1>
         <ArtworkGrid artworks={artworks} />
-      </main>
+      </div>
     </>
   )
 }
 
 export async function getStaticProps() {
   const artworks = getAllArtworks()
-  return { props: { artworks } }
+  return {
+    props: {
+      artworks: artworks && artworks.length > 0 ? artworks : dummyArtworks
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add responsive Layout with navbar and footer
- update ArtworkCard and ArtworkGrid styling
- add SEOHead meta charset
- include dummy content helpers
- polish all pages with better design and fallbacks

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849262202e483318797fc4415e6dc30