### PR TITLE
Fix missing gray-matter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "gray-matter": "4.0.3",
     "next": "13.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary
- add `gray-matter` package at version `4.0.3`

## Testing
- `npm install gray-matter@4.0.3 --save` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849295c24108331a6855f507e7365c6