### PR TITLE
Fix undefined `matter` error

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,29 +1,35 @@
 import fs from 'fs'
 import path from 'path'
-import matter from 'gray-matter'
 import { remark } from 'remark'
 import html from 'remark-html'
 
+async function parseMatter(contents) {
+  const { default: matter } = await import('gray-matter')
+  return matter(contents)
+}
+
 const artworksDirectory = path.join(process.cwd(), 'content/artworks')
 
-export function getAllArtworks() {
+export async function getAllArtworks() {
   const fileNames = fs.readdirSync(artworksDirectory)
-  const artworks = fileNames.map((fileName) => {
-    const fullPath = path.join(artworksDirectory, fileName)
-    const fileContents = fs.readFileSync(fullPath, 'utf8')
-    const { data, content } = matter(fileContents)
-    return {
-      ...data,
-      description: content.trim()
-    }
-  })
+  const artworks = await Promise.all(
+    fileNames.map(async (fileName) => {
+      const fullPath = path.join(artworksDirectory, fileName)
+      const fileContents = fs.readFileSync(fullPath, 'utf8')
+      const { data, content } = await parseMatter(fileContents)
+      return {
+        ...data,
+        description: content.trim()
+      }
+    })
+  )
   return artworks
 }
 
 export async function getArtworkBySlug(slug) {
   const fullPath = path.join(artworksDirectory, `${slug}.md`)
   const fileContents = fs.readFileSync(fullPath, 'utf8')
-  const { data, content } = matter(fileContents)
+  const { data, content } = await parseMatter(fileContents)
   const processed = await remark().use(html).process(content)
   const htmlContent = processed.toString()
   return {
@@ -36,14 +42,14 @@ export function getAllArtworkSlugs() {
   return fs.readdirSync(artworksDirectory).map((fileName) => fileName.replace(/\.md$/, ''))
 }
 
-export function getAbout() {
+export async function getAbout() {
   const file = fs.readFileSync(path.join(process.cwd(), 'content/about.md'), 'utf8')
-  const { data, content } = matter(file)
+  const { data, content } = await parseMatter(file)
   return { ...data, content }
 }
 
-export function getSEO() {
+export async function getSEO() {
   const file = fs.readFileSync(path.join(process.cwd(), 'content/seo.md'), 'utf8')
-  const { data } = matter(file)
+  const { data } = await parseMatter(file)
   return data
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -21,7 +21,7 @@ export default function About({ about }) {
 
 export async function getStaticProps() {
   try {
-    const data = getAbout()
+    const data = await getAbout()
     const processed = await remark().use(html).process(data.content)
     data.html = processed.toString()
     return { props: { about: data } }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,11 +38,11 @@ export default function Home({ artworks, seo, about }) {
 }
 
 export async function getStaticProps() {
-  const artworks = getAllArtworks()
-  const seo = getSEO()
+  const artworks = await getAllArtworks()
+  const seo = await getSEO()
   const about = await (async () => {
     try {
-      const data = getAbout()
+      const data = await getAbout()
       const { remark } = await import('remark')
       const html = (await remark().use((await import('remark-html')).default).process(data.content)).toString()
       return { ...data, html }

--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -16,7 +16,7 @@ export default function Portfolio({ artworks }) {
 }
 
 export async function getStaticProps() {
-  const artworks = getAllArtworks()
+  const artworks = await getAllArtworks()
   return {
     props: {
       artworks: artworks && artworks.length > 0 ? artworks : dummyArtworks


### PR DESCRIPTION
## Summary
- load `gray-matter` dynamically in `api.js`
- update helper functions to be async
- await data retrieval in page `getStaticProps` functions

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492a3bbf1483318ddee7c8450ac3d2